### PR TITLE
Get around SSL Verify issue

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -162,9 +162,9 @@ class ApiClient
         }
         // return the result on success, rather than just TRUE
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-  
+
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-  
+
         if (! empty($queryParams)) {
             $url = ($url . '?' . http_build_query($queryParams));
         }
@@ -193,7 +193,12 @@ class ApiClient
 
         // Set user agent
         curl_setopt($curl, CURLOPT_USERAGENT, $this->config->getUserAgent());
-  
+
+        // Allow for CA CERTIFICATES to be ignored -> https://curl.haxx.se/docs/sslcerts.html
+        if ($this->config->getStopCurlSSLVerify()) {
+          curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
+        }
+
         // debugging for curl
         if ($this->config->getDebug()) {
             error_log("[DEBUG] HTTP Request body  ~BEGIN~\n".print_r($postData, true)."\n~END~\n", 3, $this->config->getDebugFile());

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -127,6 +127,13 @@ class Configuration
     protected $tempFolderPath;
 
     /**
+     * Debug switch (default set to false)
+     *
+     * @var bool
+     */
+    protected $curlSSLVerify = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -460,5 +467,28 @@ class Configuration
   
         return $report;
     }
-  
+
+    /**
+     * Allows CURL to get around CA certification issues
+     *
+     * @param bool $verify curlSSLVerify flag
+     *
+     * @return Configuration
+     */
+    public function setStopCurlSSLVerify($verify)
+    {
+      $this->curlSSLVerify = $verify;
+      return $this;
+    }
+
+    /**
+     * Gets the curlSSLVerify flag
+     *
+     * @return bool
+     */
+    public function getStopCurlSSLVerify()
+    {
+      return $this->curlSSLVerify;
+    }
+
 }


### PR DESCRIPTION
I created this in order to deal with an issue where a SES8 server was not configured correctly to deal with curl's ssl verify option. By allowing this configuration we can bypass the SSL issue